### PR TITLE
Fix the undercloud floating ip output

### DIFF
--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -183,6 +183,7 @@ resources:
       os_auth_url: {get_param: os_auth_url}
 
 outputs:
-  undercloud_host:
+  undercloud_host_floating_ip:
+    description: "floating ip of the undercloud instance"
     value:
       get_attr: [undercloud_floating_ip, undercloud_host]

--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -185,4 +185,4 @@ resources:
 outputs:
   undercloud_host:
     value:
-      get_attr: [undercloud_floating_ip, floating_ip_address]
+      get_attr: [undercloud_floating_ip, undercloud_host]


### PR DESCRIPTION
The current attribute is wrong and the output return an error. This PR will fix the attribute and return the floating_ip for undercloud