### PR TITLE
Add Identifier to the provision-subnet resource

### DIFF
--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -137,7 +137,7 @@ resources:
     type: OS::Neutron::Subnet
     properties:
       network: {get_resource: provision_network}
-      name: provision-subnet
+      name: {get_param: provision_net}
       cidr: {get_param: provision_net_cidr}
       gateway_ip: null
       enable_dhcp: false


### PR DESCRIPTION
On a tenant where several quintupleo environments exist placing the
resource identifier in the subnet name will make them easier to tell
apart. This will come in particularly useful on a CI cloud where
we expect to have mutiple stacks defined at once.