### PR TITLE
Restart openstackbmc if it dies

### DIFF
--- a/bin/install_openstackbmc.sh
+++ b/bin/install_openstackbmc.sh
@@ -86,6 +86,7 @@ After=config-bmc-ips.service
 
 [Service]
 ExecStart=/usr/local/bin/openstackbmc  --os-user $os_user --os-password $os_password --os-tenant $os_tenant --os-auth-url $os_auth_url --instance $bm_instance --address $bmc_ip
+Restart=always
 
 User=root
 StandardOutput=kmsg+console


### PR DESCRIPTION
Long lived openstackbmc services have been witnessed to exit:
http://paste.openstack.org/show/521415/

This change sets systemd to restart openstackbmc if it exits