### PR TITLE
Add shared network support for quintupleo

### DIFF
--- a/templates/env.yaml.example
+++ b/templates/env.yaml.example
@@ -13,7 +13,9 @@ parameters:
   baremetal_prefix: baremetal
   node_count: 2
   public_net: public
+  public_net_shared: false
   provision_net: provision
+  provision_net_shared: false
   # QuintupleO-specific params ignored by virtual-baremetal.yaml
   undercloud_name: undercloud
   undercloud_image: CentOS-7-x86_64-GenericCloud

--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -59,6 +59,11 @@ parameters:
     description: CIDR for provision network subnet
     default: 192.0.2.0/24
 
+  provision_net_shared:
+    type: boolean
+    description: Whether this network should be shared across all tenants
+    default: false
+
   public_net:
     type: string
     description: Name of the overcloud external network
@@ -68,6 +73,11 @@ parameters:
     type: string
     description: CIDR for external network subnet
     default: 10.0.0.0/24
+
+  public_net_shared:
+    type: boolean
+    description: Whether this network should be shared across all tenants
+    default: false
 
   bmc_prefix:
     type: string
@@ -132,6 +142,7 @@ resources:
     type: OS::Neutron::Net
     properties:
         name: {get_param: provision_net}
+        shared: {get_param: provision_net_shared}
 
   provision_subnet:
     type: OS::Neutron::Subnet
@@ -146,6 +157,7 @@ resources:
     type: OS::Neutron::Net
     properties:
       name: {get_param: public_net}
+      shared: {get_param: public_net_shared}
 
   public_subnet:
     type: OS::Neutron::Subnet


### PR DESCRIPTION
Because of some changes we are wanting to make in
nodepool.openstack.org, we need the ability to control the shared
network setting.

We'll be now using 2 projects to configure tripleo-ci, so baremetal
nodes and zuul workers will not be in the same project any more. This
means we need to share networks between more then 1 project.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>