### PR TITLE
WIP: add undercloud-like extra nodes to OVB

### DIFF
--- a/templates/env.yaml.example
+++ b/templates/env.yaml.example
@@ -34,6 +34,13 @@ parameters:
 ## Uncomment the following to use no floating ip
 #  OS::OVB::UndercloudFloating: templates/undercloud-floating-none.yaml
 
+#resource_registry:
+## Uncomment the following to use an existing floating ip
+#  OS::OVB::ExtranodeFloating: templates/extranode-floating-existing.yaml
+
+## Uncomment the following to use no floating ip
+#  OS::OVB::ExtranodeFloating: templates/extranode-floating-none.yaml
+
 ## Uncomment the following to create a private network
 #  OS::OVB::PrivateNetwork: templates/private-net-create.yaml
 
@@ -53,3 +60,5 @@ parameters:
 
 ## Uncomment to deploy a quintupleo environment without an undercloud.
 #  OS::OVB::UndercloudEnvironment: OS::Heat::None
+## Comment to deploy a quintupleo environment with extranodes.
+OS::OVB::ExtraNodeEnvironment: OS::Heat::None

--- a/templates/extranode-floating-existing.yaml
+++ b/templates/extranode-floating-existing.yaml
@@ -1,0 +1,35 @@
+heat_template_version: 2015-04-30
+
+# Template that creates a new floating IP to access the extranode
+
+parameters:
+  external_net:
+    type: string
+    default: external
+    description: An external network from which floating ips can be provisioned
+
+  extranode_port:
+    type: string
+    description: Port id of extranode server for floating ip
+
+  extranode_floating_ip_id:
+    type: string
+    description: ID of existing floating ip to use.
+
+  extranode_floating_ip:
+    type: string
+    description: Address of existing floating ip to use.
+    default: ''
+
+resources:
+
+  extranode_floating_ip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: {get_param: extranode_floating_ip_id}
+      port_id: {get_param: extranode_port}
+
+outputs:
+  extranode_host:
+    value:
+      get_param: extranode_floating_ip

--- a/templates/extranode-floating-none.yaml
+++ b/templates/extranode-floating-none.yaml
@@ -1,0 +1,17 @@
+heat_template_version: 2015-04-30
+
+# Template that creates a new floating IP to access the extranode
+
+parameters:
+  external_net:
+    type: string
+    default: external
+    description: An external network from which floating ips can be provisioned
+
+  extranode_port:
+    type: string
+    description: Port id of extranode server for floating ip
+
+outputs:
+  extranode_host:
+    value: 'none'

--- a/templates/extranode-floating.yaml
+++ b/templates/extranode-floating.yaml
@@ -1,0 +1,31 @@
+heat_template_version: 2015-04-30
+
+# Template that creates a new floating IP to access the undercloud
+
+parameters:
+  external_net:
+    type: string
+    default: external
+    description: An external network from which floating ips can be provisioned
+
+  undercloud_port:
+    type: string
+    description: Port id of undercloud server for floating ip
+
+resources:
+
+  undercloud_floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: {get_param: external_net}
+
+  undercloud_floating_ip_assoc:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: {get_resource: extranode_floating_ip}
+      port_id: {get_param: extranode_port}
+
+outputs:
+  extranode_host:
+    value:
+      get_attr: [extranode_floating_ip, floating_ip_address]

--- a/templates/extranode-ports-port-security.yaml
+++ b/templates/extranode-ports-port-security.yaml
@@ -1,0 +1,72 @@
+heat_template_version: 2015-10-15
+
+parameters:
+
+  extranode_name:
+    type: string
+
+  private_net:
+    type: string
+
+  provision_net:
+    type: string
+
+  public_net:
+    type: string
+
+resources:
+  extranode_sg:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'sg'
+      description: Ping and SSH
+      rules:
+      - protocol: icmp
+      - protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
+
+  private_extranode_port:
+    type: OS::Neutron::Port
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'private'
+      network: {get_param: private_net}
+      security_groups:
+      - {get_resource: extranode_sg}
+
+  provision_extranode_port:
+    type: OS::Neutron::Port
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'provision'
+      network: {get_param: provision_net}
+      port_security_enabled: False
+
+  public_extranode_port:
+    type: OS::Neutron::Port
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'public'
+      network: {get_param: public_net}
+      port_security_enabled: False
+
+outputs:
+  ports:
+    value:
+    - {port: {get_resource: private_extranode_port}}
+    - {port: {get_resource: provision_extranode_port}}
+    - {port: {get_resource: public_extranode_port}}

--- a/templates/extranode-ports.yaml
+++ b/templates/extranode-ports.yaml
@@ -1,0 +1,70 @@
+heat_template_version: 2014-10-16
+
+parameters:
+
+  undercloud_name:
+    type: string
+
+  private_net:
+    type: string
+
+  provision_net:
+    type: string
+
+  public_net:
+    type: string
+
+resources:
+  extranode_sg:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'sg'
+      description: Ping and SSH
+      rules:
+      - protocol: icmp
+      - protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
+
+  private_extranode_port:
+    type: OS::Neutron::Port
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'private'
+      network: {get_param: private_net}
+      security_groups:
+      - {get_resource: extranode_sg}
+
+  provision_extranode_port:
+    type: OS::Neutron::Port
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'provision'
+      network: {get_param: provision_net}
+
+  public_extranode_port:
+    type: OS::Neutron::Port
+    properties:
+      name:
+        list_join:
+        - '_'
+        - - {get_param: extranode_name}
+          - 'public'
+      network: {get_param: public_net}
+
+outputs:
+  ports:
+    value:
+    - {port: {get_resource: private_extranode_port}}
+    - {port: {get_resource: provision_extranode_port}}
+    - {port: {get_resource: public_extranode_port}}

--- a/templates/extranode.yaml
+++ b/templates/extranode.yaml
@@ -1,0 +1,65 @@
+heat_template_version: 2015-04-30
+
+parameters:
+  extranode_flavor:
+    type: string
+  extranode_image:
+    type: string
+  key_name:
+    type: string
+  extranode_name:
+    type: string
+  extranode_user_data_format:
+    type: string
+  extranode_user_data:
+    type: string
+  private_net:
+    type: string
+  provision_net:
+    type: string
+  public_net:
+    type: string
+  external_net:
+    type: string
+  extra_node_count:
+    type: number
+    default: 1
+    description: Number of baremetal nodes to deploy
+
+resources:
+  extranode_ports:
+    type: OS::OVB::ExtraNodePorts
+    properties:
+      extranode_name: {get_param: extranode_name}
+      private_net: {get_param: private_net}
+      provision_net: {get_param: provision_net}
+      public_net: {get_param: public_net}
+
+  extranode_server:
+    type: OS::Nova::Server
+    properties:
+      flavor: {get_param: extranode_flavor}
+      image: {get_param: extranode_image}
+      key_name: {get_param: key_name}
+      networks: {get_attr: [extranode_ports, ports]}
+      name: {get_param: extranode_name}
+      user_data_format: {get_param: extranode_user_data_format}
+      user_data: {get_param: extranode_user_data}
+
+  extranode_floating_ip:
+    type: OS::OVB::ExtraNodeFloating
+    properties:
+      external_net: {get_param: external_net}
+      extranode_port:
+        get_attr:
+        - extranode_server
+        - addresses
+        - {get_param: private_net}
+        - 0
+        - port
+
+outputs:
+  extranode_host_floating_ip:
+    description: "floating ip of the extranode instance"
+    value:
+      get_attr: [extranode_floating_ip, extranode_host]

--- a/templates/resource-registry.yaml
+++ b/templates/resource-registry.yaml
@@ -2,6 +2,7 @@ resource_registry:
   OS::OVB::ServerPair: virtual-baremetal-servers.yaml
   OS::OVB::BaremetalEnvironment: virtual-baremetal.yaml
   OS::OVB::UndercloudEnvironment: undercloud.yaml
+  OS::OVB::ExtraNodeEnvironment: extranode.yaml
   OS::OVB::UndercloudFloating: undercloud-floating.yaml
   OS::OVB::PrivateNetwork: private-net-existing.yaml
   OS::OVB::BaremetalNetworks: baremetal-networks-none.yaml


### PR DESCRIPTION
In some jobs we need extra nodes, not to be deployed by ironic, but
just booted up from regular images, like undercloud does.
Right now it's required by FreeIPA job, but I believe it's generic requirement and we'll see more jobs requiring this. So my proposal is to use undercloud-like environment for this. 
This commit exactly is for creating 1 (one) extra node. Later it should be changed to handle any amount of extra nodes.