### PR TITLE
Tripleo ui

### DIFF
--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -253,3 +253,7 @@ outputs:
     description: "floating ip of the undercloud instance"
     value:
       get_attr: [undercloud_env, undercloud_host_floating_ip]
+  undercloud_host_private_ip:
+    description: "ip of the undercloud instance on the private network"
+    value:
+      get_attr: [undercloud_env, undercloud_host_private_ip]

--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -237,7 +237,6 @@ resources:
       provision_net: {get_resource: provision_network}
       bmc_flavor: {get_param: bmc_flavor}
       bmc_prefix: {get_param: bmc_prefix}
-      bmc_flavor: {get_param: bmc_flavor}
       bmc_image: {get_param: bmc_image}
       baremetal_prefix: {get_param: baremetal_prefix}
       os_user: {get_param: os_user}

--- a/templates/undercloud-ports-port-security.yaml
+++ b/templates/undercloud-ports-port-security.yaml
@@ -23,12 +23,15 @@ resources:
         - '_'
         - - {get_param: undercloud_name}
           - 'sg'
-      description: Ping and SSH
+      description: Ping, SSH, and TripleO UI
       rules:
       - protocol: icmp
       - protocol: tcp
         port_range_min: 22
         port_range_max: 22
+      - protocol: tcp
+        port_range_min: 3000
+        port_range_max: 3000
 
   private_undercloud_port:
     type: OS::Neutron::Port

--- a/templates/undercloud-ports.yaml
+++ b/templates/undercloud-ports.yaml
@@ -23,12 +23,15 @@ resources:
         - '_'
         - - {get_param: undercloud_name}
           - 'sg'
-      description: Ping and SSH
+      description: Ping, SSH, and TripleO UI
       rules:
       - protocol: icmp
       - protocol: tcp
         port_range_min: 22
         port_range_max: 22
+      - protocol: tcp
+        port_range_min: 3000
+        port_range_max: 3000
 
   private_undercloud_port:
     type: OS::Neutron::Port

--- a/templates/undercloud-volume.yaml
+++ b/templates/undercloud-volume.yaml
@@ -73,3 +73,12 @@ outputs:
     description: "floating ip of the undercloud instance"
     value:
       get_attr: [undercloud_floating_ip, undercloud_host]
+  undercloud_host_private_ip:
+    description: "ip of the undercloud instance on the private network"
+    value:
+      get_attr:
+      - undercloud_server
+      - addresses
+      - {get_param: private_net}
+      - 0
+      - addr

--- a/templates/undercloud.yaml
+++ b/templates/undercloud.yaml
@@ -59,3 +59,12 @@ outputs:
     description: "floating ip of the undercloud instance"
     value:
       get_attr: [undercloud_floating_ip, undercloud_host]
+  undercloud_host_private_ip:
+    description: "ip of the undercloud instance on the private network"
+    value:
+      get_attr:
+      - undercloud_server
+      - addresses
+      - {get_param: private_net}
+      - 0
+      - addr


### PR DESCRIPTION
Expose outputs and ports so that quickstart can bring up an undercloud where the TripleO UI is accessible without any further effort