### PR TITLE
Print stack error message if failed to create

### DIFF
--- a/openstack_virtual_baremetal/deploy.py
+++ b/openstack_virtual_baremetal/deploy.py
@@ -219,6 +219,7 @@ def _poll_stack(stack_name,  hclient):
             print 'Stack %s created successfully' % stack_name
             done = True
         elif stack.status == 'FAILED':
+            print stack.to_dict().get('stack_status_reason')
             raise RuntimeError('Failed to create stack %s' % stack_name)
         else:
             time.sleep(10)


### PR DESCRIPTION
If stack isn't created it's impossible to see from logs why.
Add printing error message before raising exception.