### PR TITLE
Use xlarge flavor for undercloud nodes

### DIFF
--- a/doc/source/deploy/baremetal.rst
+++ b/doc/source/deploy/baremetal.rst
@@ -89,7 +89,7 @@ method, which creates most of the resources needed automatically.
 
 #. Boot a VM to serve as the undercloud::
 
-    nova boot undercloud --flavor m1.large --image centos7 --nic net-id=[tenant net uuid] --nic net-id=[provisioning net uuid]
+    nova boot undercloud --flavor m1.xlarge --image centos7 --nic net-id=[tenant net uuid] --nic net-id=[provisioning net uuid]
     neutron floatingip-create [external net uuid]
     neutron port-list
     neutron floatingip-associate [floatingip uuid] [undercloud instance port id]

--- a/environments/base.yaml
+++ b/environments/base.yaml
@@ -72,7 +72,7 @@ parameter_defaults:
 
   # Nova flavor to use for the undercloud instance
   # Type: string
-  undercloud_flavor: m1.large
+  undercloud_flavor: m1.xlarge
 
   # Image to boot as the undercloud instance
   # Type: string

--- a/templates/env.yaml.example
+++ b/templates/env.yaml.example
@@ -17,7 +17,7 @@ parameters:
   # QuintupleO-specific params ignored by virtual-baremetal.yaml
   undercloud_name: undercloud
   undercloud_image: CentOS-7-x86_64-GenericCloud
-  undercloud_flavor: m1.large
+  undercloud_flavor: m1.xlarge
   external_net: external
   public_net_shared: false
   provision_net_shared: false

--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -96,7 +96,7 @@ parameters:
 
   undercloud_flavor:
     type: string
-    default: m1.large
+    default: m1.xlarge
     description: Nova flavor to use for the undercloud instance
 
   undercloud_image:


### PR DESCRIPTION
Minimal requirements for undercloud nodes are described here:
https://images.rdoproject.org/docs/baremetal/requirements.html

Specifically, it says:

"The undercloud VM or baremetal machine requires: [...] 16 GB free
memory"

It's not just documentation that asks to change default flavor. If you
try to deploy using tripleo-quickstart in RDO cloud / OVB, you will hit
both tripleo-validations failures like:

There are 4 cores in the system, but there should be at least 8.
The RAM on the undercloud node is 7822 MB, the minimal recommended value
is 16384 MB.

And even when validations are ignored, the resulting environment fails
because mariadb (or another crucial service) is killed by oom-killer. I
personally experienced mariadb killed and as a result, heat-api
failing when listing stacks with ECONNREFUSED from db server, which
finally resulted in overcloud deployment failure.

xlarge is the smallest default flavor that provides 16gb ram, and so
this patch uses this flavor.