### PR TITLE
Routed networks - - Add external gateways

### DIFF
--- a/templates/dhcp-relay.yaml
+++ b/templates/dhcp-relay.yaml
@@ -19,6 +19,21 @@ parameters:
       The base image for the dhcrelay instance.  A CentOS 7 image is currently
       the only one supported.
 
+  dhcp_relay_provision_address:
+    type: string
+    description: DHCP relay address on the provision network subnet
+    default: 192.168.24.253
+
+  dhcp_relay_provision2_address:
+    type: string
+    description: DHCP relay address on the provision2 network subnet
+    default: 192.168.25.253
+
+  dhcp_relay_provision3_address:
+    type: string
+    description: DHCP relay address on the provision3 network subnet
+    default: 192.168.26.253
+
   dhcp_ips:
     type: json
     description: |
@@ -44,6 +59,8 @@ resources:
       name: dhcp_relay_port_provision
       network: {get_param: [networks, provision]}
       port_security_enabled: False
+      fixed_ips:
+       - ip_address: {get_param: dhcp_relay_provision_address}
 
   dhcp_relay_port_provision2:
     type: OS::Neutron::Port
@@ -51,6 +68,8 @@ resources:
       name: dhcp_relay_port_provision2
       network: {get_param: [networks, provision2]}
       port_security_enabled: False
+      fixed_ips:
+       - ip_address: {get_param: dhcp_relay_provision2_address}
 
   dhcp_relay_port_provision3:
     type: OS::Neutron::Port
@@ -58,6 +77,8 @@ resources:
       name: dhcp_relay_port_provision3
       network: {get_param: [networks, provision3]}
       port_security_enabled: False
+      fixed_ips:
+       - ip_address: {get_param: dhcp_relay_provision3_address}
 
   init_networks:
     type: OS::Heat::CloudConfig

--- a/templates/quintupleo.yaml
+++ b/templates/quintupleo.yaml
@@ -212,3 +212,4 @@ outputs:
       map_merge:
       - get_attr: [undercloud_networks, provision_network_routers]
       - get_attr: [baremetal_env, baremetal_networks_routers_addresses]
+      - get_attr: [undercloud_networks, public_network_router]

--- a/templates/undercloud-networks-public-router.yaml
+++ b/templates/undercloud-networks-public-router.yaml
@@ -26,10 +26,19 @@ parameters:
     description: CIDR for external network subnet
     default: 10.0.0.0/24
 
+  public_net_router_address:
+    type: string
+    description: Router address for the public network subnet
+    default: 10.0.0.254
+
   public_net_shared:
     type: boolean
     description: Whether this network should be shared across all tenants
     default: false
+
+  external_net:
+    type: string
+    description: An external network for the networks to route to
 
 resources:
   provision_network:
@@ -62,13 +71,35 @@ resources:
       gateway_ip: null
       enable_dhcp: false
 
+  public_router:
+    type: OS::Neutron::Router
+    properties:
+      name: public-router
+      external_gateway_info:
+        network: {get_param: external_net}
+
+  public_router_port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: public_network}
+      port_security_enabled: false
+      fixed_ips:
+       - ip_address: {get_param: public_net_router_address}
+
+  public_router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: public_router}
+      port: {get_resource: public_router_port}
+
 outputs:
   networks:
     value:
       provision: {get_resource: provision_network}
       public: {get_resource: public_network}
-  # The provision and public network routers is here for compatibility only
+  # The provision_network_routers is here for compatibility only
   provision_network_routers:
-    value: null
+    value: {}
   public_network_router:
-    value: null
+    value:
+      public_router: {get_attr: [public_router_port,  fixed_ips, 0, ip_address]}

--- a/templates/undercloud-networks-routed.yaml
+++ b/templates/undercloud-networks-routed.yaml
@@ -71,10 +71,19 @@ parameters:
     description: CIDR for external network subnet
     default: 10.0.0.0/24
 
+  public_net_router_address:
+    type: string
+    description: Router address for the public network subnet
+    default: 10.0.0.254
+
   public_net_shared:
     type: boolean
     description: Whether this network should be shared across all tenants
     default: false
+
+  external_net:
+    type: string
+    description: An external network for the networks to route to
 
 resources:
   provision_router:
@@ -184,6 +193,27 @@ resources:
       gateway_ip: null
       enable_dhcp: false
 
+  public_router:
+    type: OS::Neutron::Router
+    properties:
+      name: public-router
+      external_gateway_info:
+        network: {get_param: external_net}
+
+  public_router_port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_resource: public_network}
+      port_security_enabled: false
+      fixed_ips:
+       - ip_address: {get_param: public_net_router_address}
+
+  public_router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: {get_resource: public_router}
+      port: {get_resource: public_router_port}
+
 outputs:
   networks:
     value:
@@ -196,3 +226,6 @@ outputs:
       provision_router: {get_attr: [provision_router_port, fixed_ips, 0, ip_address]}
       provision2_router: {get_attr: [provision_router_port2, fixed_ips, 0, ip_address]}
       provision3_router: {get_attr: [provision_router_port3, fixed_ips, 0, ip_address]}
+  public_network_router:
+    value:
+      public_router: {get_attr: [public_router_port,  fixed_ips, 0, ip_address]}

--- a/templates/undercloud-networks-routed.yaml
+++ b/templates/undercloud-networks-routed.yaml
@@ -90,6 +90,8 @@ resources:
     type: OS::Neutron::Router
     properties:
       name: provision-router
+      external_gateway_info:
+        network: {get_param: external_net}
 
   provision_network:
     type: OS::Neutron::Net


### PR DESCRIPTION
- Add's external_gateway_info to the provisioning router.
  Using the undercloud as the default router is not-practical when nodes are not on the same L2 network as the undercloud.
- Add a router for the public_net with external_gateway_info.
    TripleO Controller nodes use the External network as the default gateway, so this network also need external gateway info so that these nodes can reach external resources such as ntp servers, dnsservers etc.

**UPDATE** Also fixed-ip's required for the dhcp-relay instance provision interfaces.

(I closed PR #51 and fixed up my mistakes to avoid having commit's with silly mistakes. Hope I got it right this time. :) )